### PR TITLE
(Feat): New info metrics for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ Usage of gcp-exporter:
       Disables the metrics collector for Cloud Eventarc
   --collector.functions.disable
       Disables the metrics collector for Cloud Functions
-  -collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable
+  --collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable
       Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics
-  -collector.gke.disable
+  --collector.gke.disable
       Disables the metrics collector for Google Kubernetes Engine (GKE)
   --collector.iam.disable
       Disables the metrics collector for Cloud IAM
@@ -296,8 +296,8 @@ Please file issues
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
 |`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|
 |`gcp_iam_service_accounts`|Gauge|Number of Service Accounts|
-|`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.config` flag is set|
-|`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.config` flag is set|
+|`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable` flag is set|
+|`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable` flag is set|
 |`gcp_gke_nodes`|Gauge|Number of nodes currently in the Cluster|
 |`gcp_gke_up`|Gauge|1 if the Cluster is running, 0 otherwise|
 |`gcp_storage_buckets`|Gauge|Number of buckets|

--- a/README.md
+++ b/README.md
@@ -247,10 +247,10 @@ Usage of gcp-exporter:
       Disables the metrics collector for Cloud Eventarc
   --collector.functions.disable
       Disables the metrics collector for Cloud Functions
-  --collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable
-      Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics
   --collector.gke.disable
       Disables the metrics collector for Google Kubernetes Engine (GKE)
+  --collector.gke.extendedMetrics.enable
+      Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics
   --collector.iam.disable
       Disables the metrics collector for Cloud IAM
   --collector.logging.disable
@@ -296,8 +296,8 @@ Please file issues
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
 |`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|
 |`gcp_iam_service_accounts`|Gauge|Number of Service Accounts|
-|`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable` flag is set|
-|`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable` flag is set|
+|`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
+|`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
 |`gcp_gke_nodes`|Gauge|Number of nodes currently in the Cluster|
 |`gcp_gke_up`|Gauge|1 if the Cluster is running, 0 otherwise|
 |`gcp_storage_buckets`|Gauge|Number of buckets|

--- a/README.md
+++ b/README.md
@@ -235,39 +235,39 @@ git clone git@github.com:DazWilkin/gcp-exporter.git && cd gcp-exporter
 gcp-exporter --h
 
 Usage of gcp-exporter:
-  -collector.artifact_registry.disable
+  --collector.artifact_registry.disable
       Disables the metrics collector for the Artifact Registry
-  -collector.cloud_run.disable
+  --collector.cloud_run.disable
       Disables the metrics collector for Cloud Run
-  -collector.compute.disable
+  --collector.compute.disable
       Disables the metrics collector for Compute Engine
-  -collector.endpoints.disable
+  --collector.endpoints.disable
       Disables the metrics collector for Cloud Endpoints
-  -collector.eventarc.disable
+  --collector.eventarc.disable
       Disables the metrics collector for Cloud Eventarc
-  -collector.functions.disable
+  --collector.functions.disable
       Disables the metrics collector for Cloud Functions
-  -collector.gke.disable
+  --collector.gke.disable
       Disables the metrics collector for Google Kubernetes Engine (GKE)
-  -collector.gke.infoMetric.enable
+  --collector.gke.infoMetric.enable
       Specifies specific settings for the collector
-  -collector.iam.disable
+  --collector.iam.disable
       Disables the metrics collector for Cloud IAM
-  -collector.logging.disable
+  --collector.logging.disable
       Disables the metrics collector for Cloud Logging
-  -collector.monitoring.disable
+  --collector.monitoring.disable
       Disables the metrics collector for Cloud Monitoring
-  -collector.scheduler.disable
+  --collector.scheduler.disable
       Disables the metrics collector for Cloud Scheduler
-  -collector.storage.disable
+  --collector.storage.disable
       Disables the metrics collector for Cloud Storage
-  -endpoint string
+  --endpoint string
       The endpoint of the HTTP server (default ":9402")
-  -filter string
+  --filter string
       Filter the results of the request
-  -max_projects int
+  --max_projects int
       Maximum number of projects to include (default 10)
-  -path string
+  --path string
       The path on which Prometheus metrics will be served (default "/metrics")
 ```
 

--- a/README.md
+++ b/README.md
@@ -232,42 +232,42 @@ git clone git@github.com:DazWilkin/gcp-exporter.git && cd gcp-exporter
 ### Usage
 
 ```bash
-gcp-exporter -h
+gcp-exporter --h
 
 Usage of gcp-exporter:
-  -collector.artifact_registry.disable
+  --collector.artifact_registry.disable
     	Disables the metrics collector for the Artifact Registry
-  -collector.cloud_run.disable
+  --collector.cloud_run.disable
     	Disables the metrics collector for Cloud Run
-  -collector.compute.disable
+  --collector.compute.disable
     	Disables the metrics collector for Compute Engine
-  -collector.endpoints.disable
+  --collector.endpoints.disable
     	Disables the metrics collector for Cloud Endpoints
-  -collector.eventarc.disable
+  --collector.eventarc.disable
     	Disables the metrics collector for Cloud Eventarc
-  -collector.functions.disable
+  --collector.functions.disable
     	Disables the metrics collector for Cloud Functions
-  -collector.iam.disable
+  --collector.iam.disable
     	Disables the metrics collector for Cloud IAM
-  -collector.kubernetes.config string
+  --collector.gke.config string
     	Specifies specific settings for the collector (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
-  -collector.kubernetes.disable
-    	Disables the metrics collector for Google Kubernetes Engine (GKE)
-  -collector.logging.disable
+  --collector.gke.disable
+    	Disables the metrics collector for GKE
+  --collector.logging.disable
     	Disables the metrics collector for Cloud Logging
-  -collector.monitoring.disable
+  --collector.monitoring.disable
     	Disables the metrics collector for Cloud Monitoring
-  -collector.scheduler.disable
+  --collector.scheduler.disable
     	Disables the metrics collector for Cloud Scheduler
-  -collector.storage.disable
+  --collector.storage.disable
     	Disables the metrics collector for Cloud Storage
-  -endpoint string
+  --endpoint string
     	The endpoint of the HTTP server (default ":9402")
-  -filter string
+  --filter string
     	Filter the results of the request
-  -max_projects int
+  --max_projects int
     	Maximum number of projects to include (default 10)
-  -path string
+  --path string
     	The path on which Prometheus metrics will be served (default "/metrics")
 ```
 
@@ -296,10 +296,10 @@ Please file issues
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
 |`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|
 |`gcp_iam_service_accounts`|Gauge|Number of Service Accounts|
-|`gcp_kubernetes_engine_cluster_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `-collector.kubernetes.config` flag is set|
-|`gcp_kubernetes_engine_cluster_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `-collector.kubernetes.config` flag is set|
-|`gcp_kubernetes_engine_cluster_nodes`|Gauge|Number of nodes currently in the Cluster|
-|`gcp_kubernetes_engine_cluster_up`|Gauge|1 if the Cluster is running, 0 otherwise|
+|`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.config` flag is set|
+|`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.config` flag is set|
+|`gcp_gke_nodes`|Gauge|Number of nodes currently in the Cluster|
+|`gcp_gke_up`|Gauge|1 if the Cluster is running, 0 otherwise|
 |`gcp_storage_buckets`|Gauge|Number of buckets|
 
 ## Prometheus API
@@ -327,10 +327,10 @@ gcp_compute_engine_forwardingrules
 gcp_compute_engine_instances
 gcp_exporter_build_info
 gcp_exporter_start_time
-gcp_kubernetes_engine_cluster_info
-gcp_kubernetes_engine_cluster_node_pools_info
-gcp_kubernetes_engine_cluster_nodes
-gcp_kubernetes_engine_cluster_up
+gcp_gke_cluster_info
+gcp_gke_cluster_node_pools_info
+gcp_gke_cluster_nodes
+gcp_gke_cluster_up
 gcp_projects_count
 gcp_storage_buckets
 ```

--- a/README.md
+++ b/README.md
@@ -249,8 +249,10 @@ Usage of gcp-exporter:
     	Disables the metrics collector for the Cloud Functions
   -collector.iam.disable
     	Disables the metrics collector for the Cloud IAM
+  -collector.kubernetes.config string
+    	Specifies specific settings for the GKE collector (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
   -collector.kubernetes.disable
-    	Disables the metrics collector for the Kubernetes (GKE)
+    	Disables the metrics collector for Google Cloud Engine
   -collector.logging.disable
     	Disables the metrics collector for the Cloud Logging
   -collector.monitoring.disable
@@ -294,8 +296,10 @@ Please file issues
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
 |`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|
 |`gcp_iam_service_accounts`|Gauge|Number of Service Accounts|
-|`gcp_kubernetes_engine_cluster_nodes`|Gauge|Number of nodes currently in the cluster|
-|`gcp_kubernetes_engine_cluster_up`|Gauge|1 if the cluster is running, 0 otherwise|
+|`gcp_kubernetes_engine_cluster_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `-collector.kubernetes.config` flag is set|
+|`gcp_kubernetes_engine_cluster_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `-collector.kubernetes.config` flag is set|
+|`gcp_kubernetes_engine_cluster_nodes`|Gauge|Number of nodes currently in the Cluster|
+|`gcp_kubernetes_engine_cluster_up`|Gauge|1 if the Cluster is running, 0 otherwise|
 |`gcp_storage_buckets`|Gauge|Number of buckets|
 
 ## Prometheus API
@@ -323,6 +327,8 @@ gcp_compute_engine_forwardingrules
 gcp_compute_engine_instances
 gcp_exporter_build_info
 gcp_exporter_start_time
+gcp_kubernetes_engine_cluster_info
+gcp_kubernetes_engine_cluster_node_pools_info
 gcp_kubernetes_engine_cluster_nodes
 gcp_kubernetes_engine_cluster_up
 gcp_projects_count

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ git clone git@github.com:DazWilkin/gcp-exporter.git && cd gcp-exporter
 ### Usage
 
 ```bash
-gcp-exporter --h
+gcp-exporter --help
 
 Usage of gcp-exporter:
   --collector.artifact_registry.disable
@@ -247,10 +247,10 @@ Usage of gcp-exporter:
       Disables the metrics collector for Cloud Eventarc
   --collector.functions.disable
       Disables the metrics collector for Cloud Functions
-  --collector.gke.disable
+  -collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable
+      Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics
+  -collector.gke.disable
       Disables the metrics collector for Google Kubernetes Engine (GKE)
-  --collector.gke.infoMetric.enable
-      Specifies specific settings for the collector
   --collector.iam.disable
       Disables the metrics collector for Cloud IAM
   --collector.logging.disable

--- a/README.md
+++ b/README.md
@@ -238,29 +238,29 @@ Usage of gcp-exporter:
   -collector.artifact_registry.disable
     	Disables the metrics collector for the Artifact Registry
   -collector.cloud_run.disable
-    	Disables the metrics collector for the Cloud Run
+    	Disables the metrics collector for Cloud Run
   -collector.compute.disable
-    	Disables the metrics collector for the Compute
+    	Disables the metrics collector for Compute Engine
   -collector.endpoints.disable
-    	Disables the metrics collector for the Cloud Endpoints Services
+    	Disables the metrics collector for Cloud Endpoints
   -collector.eventarc.disable
-    	Disables the metrics collector for the Cloud Eventarc
+    	Disables the metrics collector for Cloud Eventarc
   -collector.functions.disable
-    	Disables the metrics collector for the Cloud Functions
+    	Disables the metrics collector for Cloud Functions
   -collector.iam.disable
-    	Disables the metrics collector for the Cloud IAM
+    	Disables the metrics collector for Cloud IAM
   -collector.kubernetes.config string
-    	Specifies specific settings for the Google Kubernetes Engine (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
+    	Specifies specific settings for the collector (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
   -collector.kubernetes.disable
-    	Disables the metrics collector for Google Cloud Engine
+    	Disables the metrics collector for Google Kubernetes Engine (GKE)
   -collector.logging.disable
-    	Disables the metrics collector for the Cloud Logging
+    	Disables the metrics collector for Cloud Logging
   -collector.monitoring.disable
-    	Disables the metrics collector for the Cloud Monitoring
+    	Disables the metrics collector for Cloud Monitoring
   -collector.scheduler.disable
-    	Disables the metrics collector for the Cloud Scheduler
+    	Disables the metrics collector for Cloud Scheduler
   -collector.storage.disable
-    	Disables the metrics collector for the Cloud Storage
+    	Disables the metrics collector for Cloud Storage
   -endpoint string
     	The endpoint of the HTTP server (default ":9402")
   -filter string

--- a/README.md
+++ b/README.md
@@ -235,40 +235,40 @@ git clone git@github.com:DazWilkin/gcp-exporter.git && cd gcp-exporter
 gcp-exporter --h
 
 Usage of gcp-exporter:
-  --collector.artifact_registry.disable
-    	Disables the metrics collector for the Artifact Registry
-  --collector.cloud_run.disable
-    	Disables the metrics collector for Cloud Run
-  --collector.compute.disable
-    	Disables the metrics collector for Compute Engine
-  --collector.endpoints.disable
-    	Disables the metrics collector for Cloud Endpoints
-  --collector.eventarc.disable
-    	Disables the metrics collector for Cloud Eventarc
-  --collector.functions.disable
-    	Disables the metrics collector for Cloud Functions
-  --collector.iam.disable
-    	Disables the metrics collector for Cloud IAM
-  --collector.gke.config string
-    	Specifies specific settings for the collector (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
-  --collector.gke.disable
-    	Disables the metrics collector for GKE
-  --collector.logging.disable
-    	Disables the metrics collector for Cloud Logging
-  --collector.monitoring.disable
-    	Disables the metrics collector for Cloud Monitoring
-  --collector.scheduler.disable
-    	Disables the metrics collector for Cloud Scheduler
-  --collector.storage.disable
-    	Disables the metrics collector for Cloud Storage
-  --endpoint string
-    	The endpoint of the HTTP server (default ":9402")
-  --filter string
-    	Filter the results of the request
-  --max_projects int
-    	Maximum number of projects to include (default 10)
-  --path string
-    	The path on which Prometheus metrics will be served (default "/metrics")
+  -collector.artifact_registry.disable
+      Disables the metrics collector for the Artifact Registry
+  -collector.cloud_run.disable
+      Disables the metrics collector for Cloud Run
+  -collector.compute.disable
+      Disables the metrics collector for Compute Engine
+  -collector.endpoints.disable
+      Disables the metrics collector for Cloud Endpoints
+  -collector.eventarc.disable
+      Disables the metrics collector for Cloud Eventarc
+  -collector.functions.disable
+      Disables the metrics collector for Cloud Functions
+  -collector.gke.disable
+      Disables the metrics collector for Google Kubernetes Engine (GKE)
+  -collector.gke.infoMetric.enable
+      Specifies specific settings for the collector
+  -collector.iam.disable
+      Disables the metrics collector for Cloud IAM
+  -collector.logging.disable
+      Disables the metrics collector for Cloud Logging
+  -collector.monitoring.disable
+      Disables the metrics collector for Cloud Monitoring
+  -collector.scheduler.disable
+      Disables the metrics collector for Cloud Scheduler
+  -collector.storage.disable
+      Disables the metrics collector for Cloud Storage
+  -endpoint string
+      The endpoint of the HTTP server (default ":9402")
+  -filter string
+      Filter the results of the request
+  -max_projects int
+      Maximum number of projects to include (default 10)
+  -path string
+      The path on which Prometheus metrics will be served (default "/metrics")
 ```
 
 Please file issues

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Usage of gcp-exporter:
   -collector.iam.disable
     	Disables the metrics collector for the Cloud IAM
   -collector.kubernetes.config string
-    	Specifies specific settings for the GKE collector (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
+    	Specifies specific settings for the Google Kubernetes Engine (default "{\"enableClusterAndNodePoolInfoMetric\": false}")
   -collector.kubernetes.disable
     	Disables the metrics collector for Google Cloud Engine
   -collector.logging.disable

--- a/collector/gke.go
+++ b/collector/gke.go
@@ -19,7 +19,7 @@ import (
 
 type GKECollector struct {
 	account *gcp.Account
-	EnableInfoMetricGKECollector bool
+	enableExtendedMetrics bool
 
 	Info          *prometheus.Desc
 	NodePoolsInfo *prometheus.Desc
@@ -27,13 +27,13 @@ type GKECollector struct {
 	Up            *prometheus.Desc
 }
 
-func NewGKECollector(account *gcp.Account, EnableInfoMetricGKECollector bool) *GKECollector {
+func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) *GKECollector {
 	fqName := name("gke")
 	labelKeys := []string{"project", "name", "location", "version"}
 
 	return &GKECollector{
 		account: account,
-		EnableInfoMetricGKECollector: EnableInfoMetricGKECollector,
+		enableExtendedMetrics: enableExtendedMetrics,
 		Up: prometheus.NewDesc(
 			fqName("up"),
 			"1 if the cluster is running, 0 otherwise",
@@ -117,12 +117,12 @@ func (c *GKECollector) collectClusterMetrics(p *cloudresourcemanager.Project, cl
 	ch <- prometheus.MustNewConstMetric(c.Nodes, prometheus.GaugeValue, float64(cluster.CurrentNodeCount),
 		p.ProjectId, cluster.Name, cluster.Location, cluster.CurrentNodeVersion)
 
-	if c.EnableInfoMetricGKECollector {
-		c.collectNodePoolMetrics(p, cluster, ch, clusterStatus)
+	if c.enableExtendedMetrics {
+		c.collectExtendedMetrics(p, cluster, ch, clusterStatus)
 	}
 }
 
-func (c *GKECollector) collectNodePoolMetrics(p *cloudresourcemanager.Project, cluster *container.Cluster,
+func (c *GKECollector) collectExtendedMetrics(p *cloudresourcemanager.Project, cluster *container.Cluster,
 	ch chan<- prometheus.Metric, clusterStatus float64) {
 
 	if cluster.NodePools == nil || len(cluster.NodePools) == 0 {

--- a/collector/kubernetes.go
+++ b/collector/kubernetes.go
@@ -2,9 +2,12 @@ package collector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/DazWilkin/gcp-exporter/gcp"
@@ -15,111 +18,164 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-// KubernetesCollector represents Kubernetes Engine
-type KubernetesCollector struct {
-	account *gcp.Account
-
-	Up    *prometheus.Desc
-	Nodes *prometheus.Desc
+type KubernetesCollectorConfig struct {
+	EnableClusterAndNodePoolInfoMetric bool `json:"enableClusterAndNodePoolInfoMetric"`
 }
 
-// NewKubernetesCollector creates a new KubernetesCollector
-func NewKubernetesCollector(account *gcp.Account) *KubernetesCollector {
-	fqName := name("kubernetes_engine")
-	labelKeys := []string{
-		"project",
-		"name",
-		"location",
-		"version",
+type KubernetesCollector struct {
+	account *gcp.Account
+	config KubernetesCollectorConfig
+
+	Info          *prometheus.Desc
+	NodePoolsInfo *prometheus.Desc
+	Nodes         *prometheus.Desc
+	Up            *prometheus.Desc
+}
+
+func NewKubernetesCollector(account *gcp.Account, config string) *KubernetesCollector {
+	var collectorConfig = KubernetesCollectorConfig{EnableClusterAndNodePoolInfoMetric: false}
+
+	if err := json.Unmarshal([]byte(config), &collectorConfig); err != nil {
+		log.Println("Unable to decode JSON:", err)
+	} else {
+		log.Printf("[KubernetesCollector] Config: %+v\n", collectorConfig)
 	}
+
+	fqName := name("kubernetes_engine")
+	labelKeys := []string{"project", "name", "location", "version"}
+
 	return &KubernetesCollector{
 		account: account,
-
+		config:  collectorConfig,
 		Up: prometheus.NewDesc(
 			fqName("cluster_up"),
 			"1 if the cluster is running, 0 otherwise",
-			labelKeys,
+			labelKeys, nil,
+		),
+		Info: prometheus.NewDesc(
+			fqName("cluster_info"),
+			"Cluster control plane information. 1 if the cluster is running, 0 otherwise",
+			append(labelKeys, "id", "mode", "endpoint", "network", "subnetwork",
+				"initial_cluster_version", "node_pools_count"),
 			nil,
 		),
 		Nodes: prometheus.NewDesc(
 			fqName("cluster_nodes"),
 			"Number of nodes currently in the cluster",
-			labelKeys,
+			labelKeys, nil,
+		),
+		NodePoolsInfo: prometheus.NewDesc(
+			fqName("cluster_node_pools_info"),
+			"Cluster Node Pools Information. 1 if the Node Pool is running, 0 otherwise",
+			append(labelKeys, "etag", "cluster_id", "autoscaling", "disk_size_gb",
+				"disk_type", "image_type", "machine_type", "locations", "spot", "preemptible"),
 			nil,
 		),
 	}
 }
 
-// Collect implements Prometheus' Collector interface and is used to collect metrics
 func (c *KubernetesCollector) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 	containerService, err := container.NewService(ctx)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 
-	// Enumerate all of the projects
 	var wg sync.WaitGroup
 	for _, p := range c.account.Projects {
 		wg.Add(1)
 		go func(p *cloudresourcemanager.Project) {
 			defer wg.Done()
-			log.Printf("[KubernetesCollector:go] Project: %s", p.ProjectId)
-			parent := fmt.Sprintf("projects/%s/locations/-", p.ProjectId)
-			resp, err := containerService.Projects.Locations.Clusters.List(parent).Context(ctx).Do()
-			if err != nil {
-				if e, ok := err.(*googleapi.Error); ok {
-					if e.Code == http.StatusForbidden {
-						// Probably (!) Kubernetes Engine API has not been enabled for Project (p)
-						return
-					}
-
-					log.Printf("Google API Error: %d [%s]", e.Code, e.Message)
-					return
-				}
-
-				log.Println(err)
-				return
-			}
-
-			for _, cluster := range resp.Clusters {
-				log.Printf("[KubernetesCollector] cluster: %s", cluster.Name)
-				ch <- prometheus.MustNewConstMetric(
-					c.Up,
-					prometheus.CounterValue,
-					func(c *container.Cluster) (result float64) {
-						if c.Status == "RUNNING" {
-							result = 1.0
-						}
-						return result
-					}(cluster),
-					[]string{
-						p.ProjectId,
-						cluster.Name,
-						cluster.Location,
-						cluster.CurrentNodeVersion,
-					}...,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					c.Nodes,
-					prometheus.GaugeValue,
-					float64(cluster.CurrentNodeCount),
-					[]string{
-						p.ProjectId,
-						cluster.Name,
-						cluster.Location,
-						cluster.CurrentNodeVersion,
-					}...,
-				)
-			}
+			c.collectProjectMetrics(ctx, containerService, p, ch)
 		}(p)
 	}
 	wg.Wait()
-
 }
 
-// Describe implements Prometheus' Collector interface and is used to describe metrics
+func (c *KubernetesCollector) collectProjectMetrics(ctx context.Context, containerService *container.Service,
+	p *cloudresourcemanager.Project, ch chan<- prometheus.Metric) {
+
+	log.Printf("[KubernetesCollector:go] Project: %s", p.ProjectId)
+	parent := fmt.Sprintf("projects/%s/locations/-", p.ProjectId)
+	resp, err := containerService.Projects.Locations.Clusters.List(parent).Context(ctx).Do()
+
+	if err != nil {
+		if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {
+			log.Printf("Google API Error: %d [%s]", e.Code, e.Message)
+			return
+		}
+		log.Println("Google API Error:", err)
+		return
+	}
+
+	for _, cluster := range resp.Clusters {
+		c.collectClusterMetrics(p, cluster, ch)
+	}
+}
+
+func (c *KubernetesCollector) collectClusterMetrics(p *cloudresourcemanager.Project, cluster *container.Cluster,
+	ch chan<- prometheus.Metric) {
+
+	log.Printf("[KubernetesCollector] cluster: %s", cluster.Name)
+
+	clusterStatus := 0.0
+	if cluster.Status == "RUNNING" {
+		clusterStatus = 1.0
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.Up, prometheus.GaugeValue, clusterStatus,
+		p.ProjectId, cluster.Name, cluster.Location, cluster.CurrentMasterVersion)
+
+	ch <- prometheus.MustNewConstMetric(c.Nodes, prometheus.GaugeValue, float64(cluster.CurrentNodeCount),
+		p.ProjectId, cluster.Name, cluster.Location, cluster.CurrentNodeVersion)
+
+	if c.config.EnableClusterAndNodePoolInfoMetric {
+		c.collectNodePoolMetrics(p, cluster, ch, clusterStatus)
+	}
+}
+
+func (c *KubernetesCollector) collectNodePoolMetrics(p *cloudresourcemanager.Project, cluster *container.Cluster,
+	ch chan<- prometheus.Metric, clusterStatus float64) {
+
+	if cluster.NodePools == nil || len(cluster.NodePools) == 0 {
+		return
+	}
+
+	nodePoolsSize := strconv.Itoa(len(cluster.NodePools))
+	clusterMode := "Standard"
+
+	if cluster.Autopilot != nil && cluster.Autopilot.Enabled {
+		clusterMode = "Autopilot"
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.Info, prometheus.GaugeValue, clusterStatus,
+		p.ProjectId, cluster.Name, cluster.Location, cluster.CurrentMasterVersion,
+		cluster.Id, clusterMode, cluster.Endpoint, cluster.Network, cluster.Subnetwork,
+		cluster.InitialClusterVersion, nodePoolsSize)
+
+	for _, nodePool := range cluster.NodePools {
+		nodePoolStatus := 0.0
+		if nodePool.Status == "RUNNING" {
+			nodePoolStatus = 1.0
+		}
+
+		boolToString := func(b bool) string { return strconv.FormatBool(b) }
+
+		ch <- prometheus.MustNewConstMetric(c.NodePoolsInfo, prometheus.GaugeValue, nodePoolStatus,
+			p.ProjectId, nodePool.Name, cluster.Location, nodePool.Version, nodePool.Etag, cluster.Id,
+			boolToString(nodePool.Autoscaling.Enabled),
+			strconv.FormatInt(nodePool.Config.DiskSizeGb, 10), nodePool.Config.DiskType,
+			nodePool.Config.ImageType, nodePool.Config.MachineType,
+			strings.Join(nodePool.Locations, ","),
+			boolToString(nodePool.Config.Spot),
+			boolToString(nodePool.Config.Preemptible))
+	}
+}
+
 func (c *KubernetesCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.Up
+	ch <- c.Info
+	ch <- c.NodePoolsInfo
 	ch <- c.Nodes
+	ch <- c.Up
 }

--- a/main.go
+++ b/main.go
@@ -39,13 +39,13 @@ var (
 	disableEventarcCollector         = flag.Bool("collector.eventarc.disable", false, "Disables the metrics collector for Cloud Eventarc")
 	disableFunctionsCollector        = flag.Bool("collector.functions.disable", false, "Disables the metrics collector for Cloud Functions")
 	disableIAMCollector              = flag.Bool("collector.iam.disable", false, "Disables the metrics collector for Cloud IAM")
-	disableKubernetesCollector       = flag.Bool("collector.kubernetes.disable", false, "Disables the metrics collector for Google Cloud Engine")
+	disableKubernetesCollector       = flag.Bool("collector.kubernetes.disable", false, "Disables the metrics collector for Google Kubernetes Engine (GKE)")
 	disableLoggingCollector          = flag.Bool("collector.logging.disable", false, "Disables the metrics collector for Cloud Logging")
 	disableMonitoringCollector       = flag.Bool("collector.monitoring.disable", false, "Disables the metrics collector for Cloud Monitoring")
 	disableSchedulerCollector        = flag.Bool("collector.scheduler.disable", false, "Disables the metrics collector for Cloud Scheduler")
 	disableStorageCollector          = flag.Bool("collector.storage.disable", false, "Disables the metrics collector for Cloud Storage")
 
-	ConfigKubernetesCollector				 = flag.String("collector.kubernetes.config", `{"enableClusterAndNodePoolInfoMetric": false}`, "Specifies specific settings for the GKE collector")
+	ConfigKubernetesCollector				 = flag.String("collector.kubernetes.config", `{"enableClusterAndNodePoolInfoMetric": false}`, "Specifies specific settings for the collector")
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -39,11 +39,13 @@ var (
 	disableEventarcCollector         = flag.Bool("collector.eventarc.disable", false, "Disables the metrics collector for Cloud Eventarc")
 	disableFunctionsCollector        = flag.Bool("collector.functions.disable", false, "Disables the metrics collector for Cloud Functions")
 	disableIAMCollector              = flag.Bool("collector.iam.disable", false, "Disables the metrics collector for Cloud IAM")
-	disableKubernetesCollector       = flag.Bool("collector.kubernetes.disable", false, "Disables the metrics collector for GKE")
+	disableKubernetesCollector       = flag.Bool("collector.kubernetes.disable", false, "Disables the metrics collector for Google Cloud Engine")
 	disableLoggingCollector          = flag.Bool("collector.logging.disable", false, "Disables the metrics collector for Cloud Logging")
 	disableMonitoringCollector       = flag.Bool("collector.monitoring.disable", false, "Disables the metrics collector for Cloud Monitoring")
 	disableSchedulerCollector        = flag.Bool("collector.scheduler.disable", false, "Disables the metrics collector for Cloud Scheduler")
 	disableStorageCollector          = flag.Bool("collector.storage.disable", false, "Disables the metrics collector for Cloud Storage")
+
+	ConfigKubernetesCollector				 = flag.String("collector.kubernetes.config", `{"enableClusterAndNodePoolInfoMetric": false}`, "Specifies specific settings for the GKE collector")
 )
 
 const (
@@ -115,7 +117,7 @@ func main() {
 		"eventarc":          {func(account *gcp.Account) prometheus.Collector { return collector.NewEventarcCollector(account) }, disableEventarcCollector},
 		"functions":         {func(account *gcp.Account) prometheus.Collector { return collector.NewFunctionsCollector(account) }, disableFunctionsCollector},
 		"iam":               {func(account *gcp.Account) prometheus.Collector { return collector.NewIAMCollector(account) }, disableIAMCollector},
-		"kubernetes":        {func(account *gcp.Account) prometheus.Collector { return collector.NewKubernetesCollector(account) }, disableKubernetesCollector},
+		"kubernetes":        {func(account *gcp.Account) prometheus.Collector { return collector.NewKubernetesCollector(account, *ConfigKubernetesCollector) }, disableKubernetesCollector},
 		"logging":           {func(account *gcp.Account) prometheus.Collector { return collector.NewLoggingCollector(account) }, disableLoggingCollector},
 		"monitoring":        {func(account *gcp.Account) prometheus.Collector { return collector.NewMonitoringCollector(account) }, disableMonitoringCollector},
 		"scheduler":         {func(account *gcp.Account) prometheus.Collector { return collector.NewSchedulerCollector(account) }, disableSchedulerCollector},

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ var (
 	disableSchedulerCollector        = flag.Bool("collector.scheduler.disable", false, "Disables the metrics collector for Cloud Scheduler")
 	disableStorageCollector          = flag.Bool("collector.storage.disable", false, "Disables the metrics collector for Cloud Storage")
 
-	EnableControlPlaneAndNodePoolInfoMetricsGKECollector = flag.Bool("collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable", false, "Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics")
+	EnableExtendedMetricsGKECollector = flag.Bool("collector.gke.extendedMetrics.enable", false, "Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics")
 )
 
 const (
@@ -117,7 +117,7 @@ func main() {
 		"eventarc":          {func(account *gcp.Account) prometheus.Collector { return collector.NewEventarcCollector(account) }, disableEventarcCollector},
 		"functions":         {func(account *gcp.Account) prometheus.Collector { return collector.NewFunctionsCollector(account) }, disableFunctionsCollector},
 		"iam":               {func(account *gcp.Account) prometheus.Collector { return collector.NewIAMCollector(account) }, disableIAMCollector},
-		"gke":               {func(account *gcp.Account) prometheus.Collector { return collector.NewGKECollector(account, *EnableControlPlaneAndNodePoolInfoMetricsGKECollector) }, disableGKECollector},
+		"gke":               {func(account *gcp.Account) prometheus.Collector { return collector.NewGKECollector(account, *EnableExtendedMetricsGKECollector) }, disableGKECollector},
 		"logging":           {func(account *gcp.Account) prometheus.Collector { return collector.NewLoggingCollector(account) }, disableLoggingCollector},
 		"monitoring":        {func(account *gcp.Account) prometheus.Collector { return collector.NewMonitoringCollector(account) }, disableMonitoringCollector},
 		"scheduler":         {func(account *gcp.Account) prometheus.Collector { return collector.NewSchedulerCollector(account) }, disableSchedulerCollector},

--- a/main.go
+++ b/main.go
@@ -39,13 +39,13 @@ var (
 	disableEventarcCollector         = flag.Bool("collector.eventarc.disable", false, "Disables the metrics collector for Cloud Eventarc")
 	disableFunctionsCollector        = flag.Bool("collector.functions.disable", false, "Disables the metrics collector for Cloud Functions")
 	disableIAMCollector              = flag.Bool("collector.iam.disable", false, "Disables the metrics collector for Cloud IAM")
-	disableKubernetesCollector       = flag.Bool("collector.kubernetes.disable", false, "Disables the metrics collector for Google Kubernetes Engine (GKE)")
+	disableGKECollector      			   = flag.Bool("collector.gke.disable", false, "Disables the metrics collector for Google Kubernetes Engine (GKE)")
 	disableLoggingCollector          = flag.Bool("collector.logging.disable", false, "Disables the metrics collector for Cloud Logging")
 	disableMonitoringCollector       = flag.Bool("collector.monitoring.disable", false, "Disables the metrics collector for Cloud Monitoring")
 	disableSchedulerCollector        = flag.Bool("collector.scheduler.disable", false, "Disables the metrics collector for Cloud Scheduler")
 	disableStorageCollector          = flag.Bool("collector.storage.disable", false, "Disables the metrics collector for Cloud Storage")
 
-	ConfigKubernetesCollector				 = flag.String("collector.kubernetes.config", `{"enableClusterAndNodePoolInfoMetric": false}`, "Specifies specific settings for the collector")
+	EnableInfoMetricGKECollector		 = flag.Bool("collector.gke.infoMetric.enable", false, "Specifies specific settings for the collector")
 )
 
 const (
@@ -117,7 +117,7 @@ func main() {
 		"eventarc":          {func(account *gcp.Account) prometheus.Collector { return collector.NewEventarcCollector(account) }, disableEventarcCollector},
 		"functions":         {func(account *gcp.Account) prometheus.Collector { return collector.NewFunctionsCollector(account) }, disableFunctionsCollector},
 		"iam":               {func(account *gcp.Account) prometheus.Collector { return collector.NewIAMCollector(account) }, disableIAMCollector},
-		"kubernetes":        {func(account *gcp.Account) prometheus.Collector { return collector.NewKubernetesCollector(account, *ConfigKubernetesCollector) }, disableKubernetesCollector},
+		"gke":               {func(account *gcp.Account) prometheus.Collector { return collector.NewGKECollector(account, *EnableInfoMetricGKECollector) }, disableGKECollector},
 		"logging":           {func(account *gcp.Account) prometheus.Collector { return collector.NewLoggingCollector(account) }, disableLoggingCollector},
 		"monitoring":        {func(account *gcp.Account) prometheus.Collector { return collector.NewMonitoringCollector(account) }, disableMonitoringCollector},
 		"scheduler":         {func(account *gcp.Account) prometheus.Collector { return collector.NewSchedulerCollector(account) }, disableSchedulerCollector},

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ var (
 	disableSchedulerCollector        = flag.Bool("collector.scheduler.disable", false, "Disables the metrics collector for Cloud Scheduler")
 	disableStorageCollector          = flag.Bool("collector.storage.disable", false, "Disables the metrics collector for Cloud Storage")
 
-	EnableInfoMetricGKECollector     = flag.Bool("collector.gke.infoMetric.enable", false, "Specifies specific settings for the collector")
+	EnableControlPlaneAndNodePoolInfoMetricsGKECollector = flag.Bool("collector.gke.ControlPlaneAndNodePoolInfoMetrics.enable", false, "Enable the metrics collector for Google Kubernetes Engine (GKE) to collect ControlPlane and NodePool metrics")
 )
 
 const (
@@ -117,7 +117,7 @@ func main() {
 		"eventarc":          {func(account *gcp.Account) prometheus.Collector { return collector.NewEventarcCollector(account) }, disableEventarcCollector},
 		"functions":         {func(account *gcp.Account) prometheus.Collector { return collector.NewFunctionsCollector(account) }, disableFunctionsCollector},
 		"iam":               {func(account *gcp.Account) prometheus.Collector { return collector.NewIAMCollector(account) }, disableIAMCollector},
-		"gke":               {func(account *gcp.Account) prometheus.Collector { return collector.NewGKECollector(account, *EnableInfoMetricGKECollector) }, disableGKECollector},
+		"gke":               {func(account *gcp.Account) prometheus.Collector { return collector.NewGKECollector(account, *EnableControlPlaneAndNodePoolInfoMetricsGKECollector) }, disableGKECollector},
 		"logging":           {func(account *gcp.Account) prometheus.Collector { return collector.NewLoggingCollector(account) }, disableLoggingCollector},
 		"monitoring":        {func(account *gcp.Account) prometheus.Collector { return collector.NewMonitoringCollector(account) }, disableMonitoringCollector},
 		"scheduler":         {func(account *gcp.Account) prometheus.Collector { return collector.NewSchedulerCollector(account) }, disableSchedulerCollector},

--- a/main.go
+++ b/main.go
@@ -39,13 +39,13 @@ var (
 	disableEventarcCollector         = flag.Bool("collector.eventarc.disable", false, "Disables the metrics collector for Cloud Eventarc")
 	disableFunctionsCollector        = flag.Bool("collector.functions.disable", false, "Disables the metrics collector for Cloud Functions")
 	disableIAMCollector              = flag.Bool("collector.iam.disable", false, "Disables the metrics collector for Cloud IAM")
-	disableGKECollector      			   = flag.Bool("collector.gke.disable", false, "Disables the metrics collector for Google Kubernetes Engine (GKE)")
+	disableGKECollector              = flag.Bool("collector.gke.disable", false, "Disables the metrics collector for Google Kubernetes Engine (GKE)")
 	disableLoggingCollector          = flag.Bool("collector.logging.disable", false, "Disables the metrics collector for Cloud Logging")
 	disableMonitoringCollector       = flag.Bool("collector.monitoring.disable", false, "Disables the metrics collector for Cloud Monitoring")
 	disableSchedulerCollector        = flag.Bool("collector.scheduler.disable", false, "Disables the metrics collector for Cloud Scheduler")
 	disableStorageCollector          = flag.Bool("collector.storage.disable", false, "Disables the metrics collector for Cloud Storage")
 
-	EnableInfoMetricGKECollector		 = flag.Bool("collector.gke.infoMetric.enable", false, "Specifies specific settings for the collector")
+	EnableInfoMetricGKECollector     = flag.Bool("collector.gke.infoMetric.enable", false, "Specifies specific settings for the collector")
 )
 
 const (


### PR DESCRIPTION
This change aims to add two new info metrics to Kubernetes.

One will be responsible for returning relevant values ​​in relation to the GKE control plane and the other in relation to the cluster's Node Pools.

With this, we will be able to create a set of dashboards that analyze the state of the cluster under the optimization of the two main components of GKE (control plane and node pools).