### PR TITLE
Version end-of-life timestamp metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ Please file issues
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
 |`gcp_gke_endof_standard_support_timestamp`|Gauge|Exports from the Cluster Control plane version's default support end date|
 |`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
-|`gcp_gke_node_pools_endof_standard_support_timestamp`|Gauge|Exports from the Cluster Node Pools version's default support end date|
-|`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
+|`gcp_gke_node_pool_endof_standard_support_timestamp`|Gauge|Exports from the Cluster Node Pools version's default support end date|
+|`gcp_gke_node_pool_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
 |`gcp_gke_nodes`|Gauge|Number of nodes currently in the Cluster|
 |`gcp_gke_up`|Gauge|1 if the Cluster is running, 0 otherwise|
 |`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Please file issues
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
 |`gcp_gke_endof_standard_support_timestamp`|Gauge|Exports from the Cluster Control plane version's default support end date|
 |`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
-|`gcp_gke_node_pools_endof_standard_support_timestamp`|Gauge|Exports from the "Cluster Node Pools version's default support end date|
+|`gcp_gke_node_pools_endof_standard_support_timestamp`|Gauge|Exports from the Cluster Node Pools version's default support end date|
 |`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
 |`gcp_gke_nodes`|Gauge|Number of nodes currently in the Cluster|
 |`gcp_gke_up`|Gauge|1 if the Cluster is running, 0 otherwise|

--- a/README.md
+++ b/README.md
@@ -294,12 +294,14 @@ Please file issues
 |`gcp_compute_engine_instances`|Gauge|Number of instances|
 |`gcp_exporter_build_info`|Counter|A metric with a constant '1' value labeled by OS version, Go version, and the Git commit of the exporter|
 |`gcp_exporter_start_time`|Gauge|Exporter start time in Unix epoch seconds|
-|`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|
-|`gcp_iam_service_accounts`|Gauge|Number of Service Accounts|
+|`gcp_gke_endof_standard_support_timestamp`|Gauge|Exports from the Cluster Control plane version's default support end date|
 |`gcp_gke_info`|Gauge|Exports detailed information from the Cluster Control Plane, including `id`, `mode`, `endpoint`, `network`, `subnetwork`, `initial_cluster_version`, and `node_pools_count`. 1 if the Cluster is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
+|`gcp_gke_node_pools_endof_standard_support_timestamp`|Gauge|Exports from the "Cluster Node Pools version's default support end date|
 |`gcp_gke_node_pools_info`|Gauge|Exports detailed information from the Cluster Node Pools, including `etag`, `cluster_id`, `autoscaling`, `disk_size_gb`, `disk_type`, `image_type`, `machine_type`, `locations`, `spot`, and `preemptible`. 1 if the Node Pool is running, 0 otherwise. Enabled when the `--collector.gke.extendedMetrics.enable` flag is set|
 |`gcp_gke_nodes`|Gauge|Number of nodes currently in the Cluster|
 |`gcp_gke_up`|Gauge|1 if the Cluster is running, 0 otherwise|
+|`gcp_iam_service_account_keys`|Gauge|Number of Service Account Keys|
+|`gcp_iam_service_accounts`|Gauge|Number of Service Accounts|
 |`gcp_storage_buckets`|Gauge|Number of buckets|
 
 ## Prometheus API

--- a/collector/gke.go
+++ b/collector/gke.go
@@ -73,14 +73,14 @@ func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKEColl
 			labelKeys, nil,
 		),
 		NodePoolsInfo: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, subsystem, "node_pools_info"),
+			prometheus.BuildFQName(prefix, subsystem, "node_pool_info"),
 			"Cluster Node Pools Information. 1 if the Node Pool is running, 0 otherwise",
 			append(labelKeys, "etag", "cluster_id", "autoscaling", "disk_size_gb",
 				"disk_type", "image_type", "machine_type", "locations", "spot", "preemptible"),
 			nil,
 		),
 		NodePoolEndOfStandardSupportTimestamp: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, subsystem, "node_pools_endof_standard_support_timestamp"),
+			prometheus.BuildFQName(prefix, subsystem, "node_pool_endof_standard_support_timestamp"),
 			"Cluster Node Pools version standard support End of Life timestamp",
 			[]string{"etag", "cluster_id"},
 			nil,

--- a/collector/gke.go
+++ b/collector/gke.go
@@ -27,7 +27,7 @@ type GKECollector struct {
 	EndOfStandardSupportTimestamp         *prometheus.Desc
 	Info                                  *prometheus.Desc
 	NodePoolEndOfStandardSupportTimestamp *prometheus.Desc
-	NodePoolsInfo                         *prometheus.Desc
+	NodePoolInfo                         *prometheus.Desc
 	Nodes                                 *prometheus.Desc
 	Up                                    *prometheus.Desc
 }
@@ -72,7 +72,7 @@ func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKEColl
 			"Number of nodes currently in the cluster",
 			labelKeys, nil,
 		),
-		NodePoolsInfo: prometheus.NewDesc(
+		NodePoolInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, subsystem, "node_pool_info"),
 			"Cluster Node Pools Information. 1 if the Node Pool is running, 0 otherwise",
 			append(labelKeys, "etag", "cluster_id", "autoscaling", "disk_size_gb",
@@ -197,7 +197,7 @@ func (c *GKECollector) collectNodePoolExtendedMetrics(ctx context.Context, p *cl
 
 		boolToString := func(b bool) string { return strconv.FormatBool(b) }
 
-		ch <- prometheus.MustNewConstMetric(c.NodePoolsInfo, prometheus.GaugeValue, nodePoolStatus,
+		ch <- prometheus.MustNewConstMetric(c.NodePoolInfo, prometheus.GaugeValue, nodePoolStatus,
 			p.ProjectId, nodePool.Name, cluster.Location, nodePool.Version, nodePool.Etag, cluster.Id,
 			boolToString(nodePollAutoScaling),
 			strconv.FormatInt(nodePool.Config.DiskSizeGb, 10), nodePool.Config.DiskType,
@@ -228,7 +228,7 @@ func (c *GKECollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.EndOfStandardSupportTimestamp
 	ch <- c.Info
 	ch <- c.NodePoolEndOfStandardSupportTimestamp
-	ch <- c.NodePoolsInfo
+	ch <- c.NodePoolInfo
 	ch <- c.Nodes
 	ch <- c.Up
 }

--- a/collector/gke.go
+++ b/collector/gke.go
@@ -27,7 +27,7 @@ type GKECollector struct {
 	EndOfStandardSupportTimestamp         *prometheus.Desc
 	Info                                  *prometheus.Desc
 	NodePoolEndOfStandardSupportTimestamp *prometheus.Desc
-	NodePoolInfo                         *prometheus.Desc
+	NodePoolInfo                          *prometheus.Desc
 	Nodes                                 *prometheus.Desc
 	Up                                    *prometheus.Desc
 }

--- a/collector/gke.go
+++ b/collector/gke.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/DazWilkin/gcp-exporter/gcp"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,10 +24,12 @@ type GKECollector struct {
 
 	enableExtendedMetrics bool
 
-	Info          *prometheus.Desc
-	NodePoolsInfo *prometheus.Desc
-	Nodes         *prometheus.Desc
-	Up            *prometheus.Desc
+	EndOfStandardSupportTimestamp         *prometheus.Desc
+	Info                                  *prometheus.Desc
+	NodePoolEndOfStandardSupportTimestamp *prometheus.Desc
+	NodePoolsInfo                         *prometheus.Desc
+	Nodes                                 *prometheus.Desc
+	Up                                    *prometheus.Desc
 }
 
 func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKECollector, error) {
@@ -58,6 +61,12 @@ func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKEColl
 				"initial_cluster_version", "node_pools_count"),
 			nil,
 		),
+		EndOfStandardSupportTimestamp: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, subsystem, "endof_standard_support_timestamp"),
+			"Cluster control plane version standand support End of Life timestamp",
+			[]string{"cluster_id"},
+			nil,
+		),
 		Nodes: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, subsystem, "nodes"),
 			"Number of nodes currently in the cluster",
@@ -68,6 +77,12 @@ func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKEColl
 			"Cluster Node Pools Information. 1 if the Node Pool is running, 0 otherwise",
 			append(labelKeys, "etag", "cluster_id", "autoscaling", "disk_size_gb",
 				"disk_type", "image_type", "machine_type", "locations", "spot", "preemptible"),
+			nil,
+		),
+		NodePoolEndOfStandardSupportTimestamp: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, subsystem, "node_pools_endof_standard_support_timestamp"),
+			"Cluster Node Pools version standand support End of Life timestamp",
+			[]string{"etag", "cluster_id"},
 			nil,
 		),
 	}, nil
@@ -104,12 +119,12 @@ func (c *GKECollector) collectProjectMetrics(ctx context.Context, containerServi
 	}
 
 	for _, cluster := range resp.Clusters {
-		c.collectClusterMetrics(p, cluster, ch)
+		c.collectClusterMetrics(ctx, p, cluster, ch, containerService)
 	}
 }
 
-func (c *GKECollector) collectClusterMetrics(p *cloudresourcemanager.Project, cluster *container.Cluster,
-	ch chan<- prometheus.Metric) {
+func (c *GKECollector) collectClusterMetrics(ctx context.Context, p *cloudresourcemanager.Project, cluster *container.Cluster,
+	ch chan<- prometheus.Metric, containerService *container.Service) {
 
 	log.Printf("[GKECollector] cluster: %s", cluster.Name)
 
@@ -125,12 +140,32 @@ func (c *GKECollector) collectClusterMetrics(p *cloudresourcemanager.Project, cl
 		p.ProjectId, cluster.Name, cluster.Location, cluster.CurrentNodeVersion)
 
 	if c.enableExtendedMetrics {
-		c.collectExtendedMetrics(p, cluster, ch, clusterStatus)
+		c.collectClusterExtendedMetrics(ctx, p, cluster, ch, containerService)
+		c.collectNodePoolExtendedMetrics(ctx, p, cluster, ch, containerService, clusterStatus)
 	}
 }
 
-func (c *GKECollector) collectExtendedMetrics(p *cloudresourcemanager.Project, cluster *container.Cluster,
-	ch chan<- prometheus.Metric, clusterStatus float64) {
+func (c *GKECollector) collectClusterExtendedMetrics(ctx context.Context, p *cloudresourcemanager.Project,
+	cluster *container.Cluster, ch chan<- prometheus.Metric, containerService *container.Service) {
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", p.ProjectId, cluster.Location, cluster.Name)
+	resp, err := containerService.Projects.Locations.Clusters.FetchClusterUpgradeInfo(parent).Context(ctx).Do()
+
+	if err != nil {
+		if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {
+			log.Printf("Google API Error: %d [%s]", e.Code, e.Message)
+			return
+		}
+		log.Println("Google API Error:", err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.EndOfStandardSupportTimestamp, prometheus.GaugeValue,
+		float64(DateToUnix(resp.EndOfStandardSupportTimestamp)), cluster.Id)
+}
+
+func (c *GKECollector) collectNodePoolExtendedMetrics(ctx context.Context, p *cloudresourcemanager.Project,
+	cluster *container.Cluster, ch chan<- prometheus.Metric, containerService *container.Service, clusterStatus float64) {
 
 	if len(cluster.NodePools) == 0 {
 		return
@@ -150,26 +185,59 @@ func (c *GKECollector) collectExtendedMetrics(p *cloudresourcemanager.Project, c
 
 	for _, nodePool := range cluster.NodePools {
 		nodePoolStatus := 0.0
+		nodePollAutoScaling := false
+
 		if nodePool.Status == "RUNNING" {
 			nodePoolStatus = 1.0
+		}
+
+		if nodePool.Autoscaling != nil && nodePool.Autoscaling.Enabled {
+			nodePollAutoScaling = nodePool.Autoscaling.Enabled
 		}
 
 		boolToString := func(b bool) string { return strconv.FormatBool(b) }
 
 		ch <- prometheus.MustNewConstMetric(c.NodePoolsInfo, prometheus.GaugeValue, nodePoolStatus,
 			p.ProjectId, nodePool.Name, cluster.Location, nodePool.Version, nodePool.Etag, cluster.Id,
-			boolToString(nodePool.Autoscaling.Enabled),
+			boolToString(nodePollAutoScaling),
 			strconv.FormatInt(nodePool.Config.DiskSizeGb, 10), nodePool.Config.DiskType,
 			nodePool.Config.ImageType, nodePool.Config.MachineType,
 			strings.Join(nodePool.Locations, ","),
 			boolToString(nodePool.Config.Spot),
 			boolToString(nodePool.Config.Preemptible))
+
+		parent := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", p.ProjectId,
+			cluster.Location, cluster.Name, nodePool.Name)
+		resp, err := containerService.Projects.Locations.Clusters.NodePools.FetchNodePoolUpgradeInfo(parent).Context(ctx).Do()
+
+		if err != nil {
+			if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {
+				log.Printf("Google API Error: %d [%s]", e.Code, e.Message)
+				return
+			}
+			log.Println("Google API Error:", err)
+			return
+		}
+
+		ch <- prometheus.MustNewConstMetric(c.NodePoolEndOfStandardSupportTimestamp, prometheus.GaugeValue,
+			float64(DateToUnix(resp.EndOfStandardSupportTimestamp)), nodePool.Etag, cluster.Id)
 	}
 }
 
 func (c *GKECollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.EndOfStandardSupportTimestamp
 	ch <- c.Info
+	ch <- c.NodePoolEndOfStandardSupportTimestamp
 	ch <- c.NodePoolsInfo
 	ch <- c.Nodes
 	ch <- c.Up
+}
+
+func DateToUnix(dateStr string) int64 {
+	layout := "2006-01-02"
+	t, err := time.Parse(layout, dateStr)
+	if err != nil {
+		return time.Now().Unix()
+	}
+	return t.Unix()
 }

--- a/collector/gke.go
+++ b/collector/gke.go
@@ -63,7 +63,7 @@ func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKEColl
 		),
 		EndOfStandardSupportTimestamp: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, subsystem, "endof_standard_support_timestamp"),
-			"Cluster control plane version standand support End of Life timestamp",
+			"Cluster control plane version standard support End of Life timestamp",
 			[]string{"cluster_id"},
 			nil,
 		),
@@ -81,7 +81,7 @@ func NewGKECollector(account *gcp.Account, enableExtendedMetrics bool) (*GKEColl
 		),
 		NodePoolEndOfStandardSupportTimestamp: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, subsystem, "node_pools_endof_standard_support_timestamp"),
-			"Cluster Node Pools version standand support End of Life timestamp",
+			"Cluster Node Pools version standard support End of Life timestamp",
 			[]string{"etag", "cluster_id"},
 			nil,
 		),
@@ -154,10 +154,10 @@ func (c *GKECollector) collectClusterExtendedMetrics(ctx context.Context, p *clo
 	if err != nil {
 		if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {
 			log.Printf("Google API Error: %d [%s]", e.Code, e.Message)
-			return
+			continue
 		}
 		log.Println("Google API Error:", err)
-		return
+		continue
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.EndOfStandardSupportTimestamp, prometheus.GaugeValue,
@@ -213,10 +213,10 @@ func (c *GKECollector) collectNodePoolExtendedMetrics(ctx context.Context, p *cl
 		if err != nil {
 			if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {
 				log.Printf("Google API Error: %d [%s]", e.Code, e.Message)
-				return
+				continue
 			}
 			log.Println("Google API Error:", err)
-			return
+			continue
 		}
 
 		ch <- prometheus.MustNewConstMetric(c.NodePoolEndOfStandardSupportTimestamp, prometheus.GaugeValue,


### PR DESCRIPTION
This change aims to add a new metric for the end of support date for a GKE version (control plane and cluster node pools).

According to the table mentioned in this [documentation](https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule-for-release-channels), GKE versions have an end of support date, after which GKE grants the right to update at its own discretion.

This metric is especially relevant when manually controlling the version, that is, when automatic upgrades are not enabled and must be controlled for legal reasons.